### PR TITLE
Change command

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Brings [jsTree](http://www.jstree.com/) functionality into your Ember app.
 
 Ember CLI addons can be installed with `npm`
 
-	ember install:addon ember-cli-jstree
+	ember install ember-cli-jstree
 
 ## Usage
 


### PR DESCRIPTION
Hello, the result with previous command is : The specified command install:addon is invalid. For available options, see `ember help`.