### PR TITLE
Remove quotes on treeObject property in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ in your controller.
 {{ember-jstree
     [...]
     eventDidChange="handleJstreeEventDidChange"
-    treeObject="jstreeObject"
+    treeObject=jstreeObject
 }}
 ````
 


### PR DESCRIPTION
Value assigned to treeObject in template needs to not have quotes in order to work.