### PR TITLE
v0.1.1

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ module.exports = {
 
     included: function (app) {
         this._super.included(app);
-        app.import(app.bowerDirectory + '/jstree/src/jstree.js');
+        app.import(app.bowerDirectory + '/jstree/dist/jstree.js');
         app.import(app.bowerDirectory + '/jstree/dist/themes/default/style.min.css');
     },
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-jstree",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "ember-cli addon for jstree http://www.jstree.com/",
   "directories": {
     "doc": "doc",


### PR DESCRIPTION
The previous build (ref: #18) removed plugins because the wrong jstree file was referenced.
This fixes that (ref: #20, #19) and increments version number to prevent confusion.