### PR TITLE
peg jQuery at this version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,7 @@
     "ember-qunit": "0.4.9",
     "ember-qunit-notifications": "0.0.7",
     "ember-resolver": "~0.1.18",
-    "jquery": "^1.11.3",
+    "jquery": "1.11.3",
     "loader.js": "ember-cli/loader.js#3.2.1",
     "qunit": "~1.18.0",
     "jstree": "git://github.com/cristinawithout/jstree.git#4cbfbe263949fa1c88e45faa1c8233348ce25352"


### PR DESCRIPTION
Newer versions of jQuery do not work with this Ember version.

See: http://stackoverflow.com/questions/34702284/getting-uncaught-error-assertion-failed-ember-views-require-jquery-between-1

This will also fix the build and allow the demo to run.