### PR TITLE
configuration typo; extracted configuration builder; version bump

### DIFF
--- a/addon/components/ember-jstree.js
+++ b/addon/components/ember-jstree.js
@@ -85,10 +85,18 @@ export default Ember.Component.extend(InboundActions, EmberJstreeActions, {
     * configuration object for jsTree
     *
     * @method _setupJsTree
-    */
+    */    
     _setupJsTree: function() {
-        var configObject = {};
+        return this.$().jstree(this._buildConfig());        
+    },
 
+    /**
+    * Builds config object for jsTree. Could be used to override config in descendant classes.
+    *
+    * @method _buildConfig
+    */    
+    _buildConfig: function(){
+        var configObject = {};
         configObject["core"] = {
             "data": this.get('data'),
             "check_callback": this.get('checkCallback')
@@ -118,7 +126,7 @@ export default Ember.Component.extend(InboundActions, EmberJstreeActions, {
 
             var stateOptions = this.get('stateOptions');
             if(stateOptions && pluginsArray.indexOf("state") !== -1) {
-                configObject["checkbox"] = stateOptions;
+                configObject["state"] = stateOptions;
             }
 
             var typesOptions = this.get('typesOptions');
@@ -131,7 +139,7 @@ export default Ember.Component.extend(InboundActions, EmberJstreeActions, {
             configObject["search"] = {"search_callback" : this.searchCallback.bind(this)};
         }
 
-        return this.$().jstree(configObject);
+        return configObject;
     },
 
     /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-jstree",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "ember-cli addon for jstree http://www.jstree.com/",
   "directories": {
     "doc": "doc",


### PR DESCRIPTION
Fixed typo in configuration.
Extracted _buildConfig method to able to override it in descendant classes.

Please republish npm package too, it points to  older version.