### PR TITLE
Added more supported actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,10 +80,13 @@ The following events have basic support included. More are on the way.
 | after_open.jstree         | eventDidOpen          |
 | after_close.jstree        | eventDidClose         |
 | changed.jstree            | eventDidChange        |
+| dehover_node.jstree       | eventDidDehoverNode   |
 | deselect_node.jstree      | eventDidDeselectNode  |
+| hover_node.jstree         | eventDidHoverNode     |
 | init.jstree               | eventDidInit          |
 | ready.jstree              | eventDidBecomeReady   |
 | redraw.jstree             | eventDidRedraw        |
+| show_node.jstree          | eventDidShowNode      |
 | select_node.jstree        | eventDidSelectNode    |
 | (destroyed - no event)    | eventDidDestroy       |
 

--- a/addon/components/ember-jstree.js
+++ b/addon/components/ember-jstree.js
@@ -332,6 +332,48 @@ export default Ember.Component.extend(InboundActions, EmberJstreeActions, {
                 }
             });
         }.bind(this));
+
+        /*
+          Event: hover_node.jstree
+          Action: eventDidHoverNode
+          triggered when a node is hovered
+        */
+        treeObject.on('hover_node.jstree', function(e, data) {
+            Ember.run(this, function() {
+                if (this.get('isDestroyed') || this.get('isDestroying')) {
+                    return;
+                }
+                this.sendAction('eventDidHoverNode', data.node);
+            });
+        }.bind(this));
+
+        /*
+          Event: dehover_node.jstree
+          Action: eventDidDehoverNode
+          triggered when a node is no longer hovered
+        */
+        treeObject.on('hover_node.jstree', function(e, data) {
+            Ember.run(this, function() {
+                if (this.get('isDestroyed') || this.get('isDestroying')) {
+                    return;
+                }
+                this.sendAction('eventDidDehoverNode', data.node);
+            });
+        }.bind(this));
+
+        /*
+          Event: show_node.jstree
+          Action: eventDidShowNode
+          triggered when a node is no longer hovered
+        */
+        treeObject.on('show_node.jstree', function(e, data) {
+            Ember.run(this, function() {
+                if (this.get('isDestroyed') || this.get('isDestroying')) {
+                    return;
+                }
+                this.sendAction('eventDidShowNode', data.node);
+            });
+        }.bind(this));
     },
 
     /**


### PR DESCRIPTION
Add hover_node (eventDidHoverNode), dehover_node (eventDidDehoverNode) and show_node (eventDidShowNode) as officially supported actions.

To support #42. Request version bump after merge as well.