### PR TITLE
Support jstree's search plugin for searching/filtering trees

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Run supported actions on the tree by registering it to your controller with the 
         contextmenuOptions=contextmenuOptions
         stateOptions=stateOptions
         typesOptions=typesOptions
+        searchOptions=searchOptions
+        searchTerm=searchTerm
         contextMenuReportClicked="contextMenuReportClicked"
         eventDidBecomeReady="handleTreeDidBecomeReady"
     }}
@@ -123,6 +125,7 @@ The following [plugins](http://www.jstree.com/plugins/) are currently supported.
 
 * Checkbox
 * Contextmenu
+* Search
 * State
 * Types
 * Wholerow

--- a/addon/components/ember-jstree.js
+++ b/addon/components/ember-jstree.js
@@ -25,6 +25,7 @@ export default Ember.Component.extend(InboundActions, EmberJstreeActions, {
     checkboxOptions:      null,
     contextmenuOptions:   null,
     typesOptions:         null,
+    searchOptions:        null,
 
     selectionDidChange:   null,
     treeObject:           null,
@@ -65,18 +66,10 @@ export default Ember.Component.extend(InboundActions, EmberJstreeActions, {
         this.send('destroy');
     },
 
-    searchCallback(str, node) {
-        if (typeof node.original === 'object') {
-            if (node.original[this.search_property]) {
-                let propValue = node.original[this.search_property];
-                if (propValue === str) {
-                    return true;
-                }
-            }
-        }
-
-        return false;
-    },
+    searchTermChanged: Ember.observer('searchTerm', function() {
+        let searchTerm = this.get('searchTerm');
+        this.getTree().search(searchTerm);
+    }),
 
     /**
     * Main setup function that registers all the plugins and sets up the core
@@ -123,6 +116,12 @@ export default Ember.Component.extend(InboundActions, EmberJstreeActions, {
                 configObject["checkbox"] = checkboxOptions;
             }
 
+            let searchOptions = this.get('searchOptions');
+            if (searchOptions && pluginsArray.indexOf("search") !== -1) {
+                searchOptions["search_callback"] = this.searchCallback;
+                configObject["search"] = searchOptions;
+            }
+
             let stateOptions = this.get('stateOptions');
             if (stateOptions && pluginsArray.indexOf("state") !== -1) {
                 configObject["state"] = stateOptions;
@@ -134,8 +133,6 @@ export default Ember.Component.extend(InboundActions, EmberJstreeActions, {
             }
 
             configObject["contextmenu"] = this._setupContextMenus(pluginsArray);
-
-            configObject["search"] = {"search_callback" : this.searchCallback.bind(this)};
         }
 
         return configObject;

--- a/addon/mixins/ember-jstree-actions.js
+++ b/addon/mixins/ember-jstree-actions.js
@@ -213,25 +213,6 @@ export default Ember.Mixin.create({
                         }
                         treeObject.jstree(true).select_node(nodes, true, true);
                     }
-                } else {
-                    if (this.plugins.indexOf("search") === -1) {
-                         Ember.assert("'search' plugin is required to perform 'selectNodes' on properties other than 'id'");
-                         return;
-                    }
-
-                    this.set('search_property', property);
-
-                    treeObject.on('search.jstree', (event, data) => {
-                        treeObject.jstree(true).select_node(data.nodes, true, true);
-                    });
-
-                    if (Ember.$.isArray(values)) {
-                        for(let i=0; i<values.length; i++) {
-                            treeObject.jstree(true).search(values[i]);
-                        }
-
-                        treeObject.jstree(true).clear_search();
-                    }
                 }
             }
         }

--- a/tests/acceptance/ember-jstree-test.js
+++ b/tests/acceptance/ember-jstree-test.js
@@ -55,6 +55,21 @@ test('Get Node button gets correct node', function(assert) {
     });
 });
 
+test('Search filters to correct nodes', function(assert) {
+    visit('/static');
+    andThen(function() {
+        assert.equal(find('.sample-tree li.jstree-hidden').length, 0, 'All nodes begin visible');
+    });
+    fillIn('.search-input', 'Single child node');
+    andThen(function() {
+        assert.equal(find('.sample-tree li:not(.jstree-hidden)').length, 1, 'Only matching node shown after search');
+    });
+    fillIn('.search-input', '');
+    andThen(function() {
+        assert.equal(find('.sample-tree li.jstree-hidden').length, 0, 'All nodes are visible after clearing search');
+    });
+});
+
 test('Has dynamic demo', function(assert) {
     assert.expect(1);
     visit('/dynamic').then(function() {

--- a/tests/dummy/app/static/controller.js
+++ b/tests/dummy/app/static/controller.js
@@ -55,7 +55,6 @@ export default Ember.Controller.extend({
 
     checkboxOptions: {"keep_selected_style" : false},
     searchOptions: {
-      'case_insensitive': true,
       'show_only_matches' : true
     },
 

--- a/tests/dummy/app/static/controller.js
+++ b/tests/dummy/app/static/controller.js
@@ -5,6 +5,7 @@ export default Ember.Controller.extend({
     jstreeSelectedNodes: Ember.A(),
     jstreeBuffer: null,
     jsonifiedBuffer: '<No output>',
+    searchTerm: '',
 
     sortedSelectedNodes: Ember.computed.sort('jstreeSelectedNodes', function(a, b) {
         if (a.text > b.text) {
@@ -46,13 +47,17 @@ export default Ember.Controller.extend({
     lastItemClicked: '',
     treeReady: false,
 
-    plugins: "checkbox, wholerow, state, types, contextmenu",
+    plugins: "checkbox, wholerow, state, search, types, contextmenu",
     themes: {
         'name': 'default',
         'responsive': true
     },
 
     checkboxOptions: {"keep_selected_style" : false},
+    searchOptions: {
+      'case_insensitive': true,
+      'show_only_matches' : true
+    },
 
     stateOptions: {
         'key': 'ember-cli-jstree-dummy'

--- a/tests/dummy/app/static/template.hbs
+++ b/tests/dummy/app/static/template.hbs
@@ -10,8 +10,10 @@
         checkboxOptions=checkboxOptions
         contextmenuOptions=contextmenuOptions
         contextMenuReportClicked="contextMenuReportClicked"
+        searchOptions=searchOptions
         stateOptions=stateOptions
         typesOptions=typesOptions
+        searchTerm=searchTerm
 
         eventDidBecomeReady="handleTreeDidBecomeReady"
 
@@ -55,6 +57,11 @@
         <button {{action "destroy"}} class="ember-test-destroy-button">Destroy</button>
         <br><br>
         <button {{action "addChildByText" "Opened node (has tooltip)"}}>Add child to "Opened node"</button>
+    </div>
+
+    <div class="search">
+      <h2>Search</h2>
+      {{input type="text" placeholder="Search" class="search-input form-control" value=searchTerm}}
     </div>
 
     <div class="buffer">


### PR DESCRIPTION
This adds two additional optional parameters for the jstree component:
-  `searchOptions` - a configuration object for the [jstree search options](https://www.jstree.com/api/#/?q=$.jstree.defaults.search)
- `searchTerm` - the term to be searched

I've added example usage to the static test app as well as acceptance tests for the behavior.

This addresses issue https://github.com/ritesh83/ember-cli-jstree/issues/53