### PR TITLE
Moves phantomjs-prebuilt from direct dependencies to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.5.1",
     "ember-resolver": "^2.0.3",
-    "loader.js": "^4.0.10"
+    "loader.js": "^4.0.10",
+    "phantomjs-prebuilt": "^2.1.12"
   },
   "keywords": [
     "ember-addon",
@@ -53,8 +54,7 @@
   "dependencies": {
     "ember-cli-babel": "^5.1.7",
     "broccoli-funnel": "^1.0.1",
-    "ember-component-inbound-actions": "1.1.0",
-    "phantomjs-prebuilt": "^2.1.12"
+    "ember-component-inbound-actions": "1.1.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",


### PR DESCRIPTION
Apps that depend on ember-cli-jstree no longer have to download phantomjs if they aren't using it.

