### PR TITLE
fix search on ie11

### DIFF
--- a/addon/components/ember-jstree.js
+++ b/addon/components/ember-jstree.js
@@ -75,7 +75,7 @@ export default Ember.Component.extend(InboundActions, EmberJstreeActions, {
         let pluginsArray = this.get('plugins');
         if (Ember.isPresent(pluginsArray)) {
             let searchOptions = this.get('searchOptions');
-            if (Ember.isPresent(searchOptions) && pluginsArray.includes('search')) {
+            if (Ember.isPresent(searchOptions) && pluginsArray.indexOf('search') >= 0) {
                 let searchTerm = this.get('searchTerm');
                 if (this.get('_searchTerm') !== searchTerm) {
                     Ember.run.next('afterRender', () => {


### PR DESCRIPTION
On IE11, when trying to determine if the search plugin should be enabled, includes() is undefined for pluginsArray.  This causes the initialization of the search plugin to fail silently.