### PR TITLE
Add worker option

### DIFF
--- a/addon/components/ember-jstree.js
+++ b/addon/components/ember-jstree.js
@@ -17,6 +17,7 @@ export default Ember.Component.extend(InboundActions, EmberJstreeActions, {
     themes:               null,
     checkCallback:        true,
     multiple:             true,
+    worker:               true,
 
     // Refresh configuration variables
     skipLoading:          false,
@@ -108,7 +109,8 @@ export default Ember.Component.extend(InboundActions, EmberJstreeActions, {
         configObject['core'] = {
             'data': this.get('data'),
             'check_callback': this.get('checkCallback'),
-            'multiple': this.get('multiple')
+            'multiple': this.get('multiple'),
+            'worker': this.get('worker')
         };
 
         let themes = this.get('themes');


### PR DESCRIPTION
This fixes issue #76 by allowing a `worker` option to be passed in. I've tested this locally and it works however I think a better design here would be to allow the passing in of a `coreOptions` hash similar to how the other plugin option hashes are being handled. This would help future proof any new core options that may be added.