### PR TITLE
Fix issue if no plugins are defined

### DIFF
--- a/addon/components/ember-jstree.js
+++ b/addon/components/ember-jstree.js
@@ -455,7 +455,8 @@ export default Component.extend(InboundActions, EmberJstreeActions, {
       });
     });
 
-    if (this.get("plugins").indexOf("checkbox") > -1) {
+    let pluginsArray = this.get("plugins");
+    if (isPresent(pluginsArray) && pluginsArray.indexOf("checkbox") > -1) {
       /*
            Event: disable_checkbox.jstree
            Action: eventDidDisableCheckbox


### PR DESCRIPTION
This fixes an issue where `.indexOf` could not be called because plugins was not defined.