### PR TITLE
Wrapped tree in conditional in case it's undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,7 +44,13 @@ module.exports = {
       destDir: "ember-cli-jstree"
     });
 
-    return mergeTrees([tree, registerVersionTree, jsTree, stylesTree], {
+    let trees = [registerVersionTree, jsTree, stylesTree];
+
+    if (tree) {
+      trees.splice(0, 0, tree);
+    }
+
+    return mergeTrees(trees, {
       overwrite: true
     });
   },


### PR DESCRIPTION
This fixes an issue I encountered in both my existing Ember 2.16 app and in a fresh 2.18 app, wherein `tree` was `undefined` and causing an exception to be thrown by Broccoli:

```
ERROR Summary:

  - broccoliBuilderErrorStack: [undefined]
  - codeFrame: [undefined]
  - errorMessage: BroccoliMergeTrees: Expected Broccoli node, got undefined for inputNodes[0]
  - errorType: [undefined]
  - location:
    - column: [undefined]
    - file: [undefined]
    - line: [undefined]
  - message: BroccoliMergeTrees: Expected Broccoli node, got undefined for inputNodes[0]
  - name: TypeError
  - nodeAnnotation: [undefined]
  - nodeName: [undefined]
  - originalErrorMessage: [undefined]
  - stack: TypeError: BroccoliMergeTrees: Expected Broccoli node, got undefined for inputNodes[0]
    at BroccoliMergeTrees.Plugin (C:\phx\my-app\node_modules\broccoli-plugin\index.js:23:13)
    at new BroccoliMergeTrees (C:\phx\my-app\node_modules\ember-cli-jstree\node_modules\broccoli-merge-trees\index.js:16:10)
    at BroccoliMergeTrees (C:\phx\my-app\node_modules\ember-cli-jstree\node_modules\broccoli-merge-trees\index.js:10:53)
    at Class.treeForVendor (C:\phx\my-app\node_modules\ember-cli-jstree\index.js:47:12)
    at Class._treeFor (C:\phx\my-app\node_modules\ember-cli\lib\models\addon.js:578:33)
    at Class.treeFor (C:\phx\my-app\node_modules\ember-cli\lib\models\addon.js:538:21)
    at project.addons.reduce (C:\phx\my-app\node_modules\ember-cli\lib\broccoli\ember-app.js:630:25)
    at Array.reduce (<anonymous>)
    at EmberApp.addonTreesFor (C:\phx\my-app\node_modules\ember-cli\lib\broccoli\ember-app.js:628:32)
    at EmberApp._processedVendorTree (C:\phx\my-app\node_modules\ember-cli\lib\broccoli\ember-app.js:1115:24)```