### PR TITLE
upgrades jstree to 3.3.7 - Fix chrome deprecation, registerElement de…

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -4327,8 +4327,9 @@ jsonify@~0.0.0:
   resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
 
 jstree@^3.3.5:
-  version "3.3.5"
-  resolved "https://registry.yarnpkg.com/jstree/-/jstree-3.3.5.tgz#9c578db32d0a643775cddd8020ad5992f4119c13"
+  version "3.3.7"
+  resolved "https://registry.yarnpkg.com/jstree/-/jstree-3.3.7.tgz#41df485d66148836ac389603a3e12f4574b06251"
+  integrity sha512-yzzalO1TbZ4HdPezO43LesGI4Wv2sB0Nl+4GfwO0YYvehGws5qtTAhlBISxfur9phMLwCtf9GjHlRx2ZLXyRnw==
   dependencies:
     jquery ">=1.9.1"
 


### PR DESCRIPTION
yarn upgrade for jstree 3.3.7, fixes chrome deprecating registerElement

closes https://github.com/ritesh83/ember-cli-jstree/issues/93